### PR TITLE
Implement fix for incorrect "linkoverview"-URLs

### DIFF
--- a/includes/ParserFunctions/LinkOverview.php
+++ b/includes/ParserFunctions/LinkOverview.php
@@ -2,6 +2,7 @@
 
 namespace MediaWiki\Skin\NORA\ParserFunctions;
 
+use MediaWiki\Title\Title;
 use Parser;
 
 /**
@@ -66,12 +67,14 @@ class LinkOverview extends MustacheParserFunction {
 			$anchor = trim( $match[2] ?? '' );
 			$description = trim( $match[3] ?? '' );
 
-			if ( empty( $link ) || empty( $anchor ) ) {
+			$linkTitle = Title::newFromText( urldecode( $link ) );
+
+			if ( empty( $link ) || empty( $anchor ) || !$linkTitle ) {
 				return wfMessage( 'nora-link-overview-invalid-items-string' )->text();
 			}
 
 			$item = [
-				'href' => $link,
+				'href' => $linkTitle->getFullURL(),
 				'name' => $anchor,
 			];
 

--- a/skin.json
+++ b/skin.json
@@ -1,6 +1,6 @@
 {
   "name": "NORA Skin",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "author": "[https://www.archixl.nl Youri van den Bogert]",
   "license-name": "© 2016-2025 ArchiXL",
   "descriptionmsg": "nora-skin-desc",


### PR DESCRIPTION
Bij het bezoeken van de NORA-wiki via een ander pad dan het standaard `/wiki/` pad werken de URL's in linkoverview-blokken niet meer goed.

Voorbeeld:
- https://www.noraonline.nl/index.php?title=Nederlandse_Overheid_Referentie_Architectuur_(NORA)&mtm_campaign=Digitaleoverheid.nl__&mtm_kwd=Hoofdpagina_wiki 

Ook werken op het moment links naar pagina's in een andere naamruimte niet goed.

Voorbeeld:
- https://www.noraonline.nl/wiki/Beheertabellen